### PR TITLE
Add test that does numbers and arrays

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ mod tests {
 }
 
 #[cfg(test)]
-mod benches {
+mod vec_benches {
     use super::*;
     use test::{black_box, Bencher};
 
@@ -187,6 +187,192 @@ mod benches {
                 b.iter(|| {
                     IteratorTester::new($iter)
                         .fold_mut_each(Vec::new(), |nums, n| mut_closure!(nums, n))
+                })
+            }
+        };
+    }
+    test!(
+        bench_simple_for,
+        bench_simple_fold,
+        bench_simple_fold_mut,
+        bench_simple_fold_mut_fold,
+        bench_simple_fold_mut_each,
+        (0i64..100_000).map(black_box)
+    );
+    test!(
+        bench_chain_for,
+        bench_chain_fold,
+        bench_chain_fold_mut,
+        bench_chain_fold_mut_fold,
+        bench_chain_fold_mut_each,
+        (0i64..50_000).chain(0..50_000).map(black_box)
+    );
+    test!(
+        bench_flat_for,
+        bench_flat_fold,
+        bench_flat_fold_mut,
+        bench_flat_fold_mut_fold,
+        bench_flat_fold_mut_each,
+        (0i64..100_000).map(std::iter::once).flat_map(black_box)
+    );
+}
+
+#[cfg(test)]
+mod num_benches {
+    use super::*;
+    use test::{black_box, Bencher};
+
+    macro_rules! mut_closure {
+        ($sum:ident, $n:ident) => {
+            if $n % 3 == 0 {
+                let n2 = $n / 3;
+                if n2 % 3 == 0 {
+                    *$sum += n2;
+                }
+            }
+        };
+    }
+
+    macro_rules! test {
+        ($name_for:ident, $name_fold:ident, $name_fold_mut:ident, $name_fold_mut_fold:ident, $name_fold_mut_each:ident, $iter:expr) => {
+            #[bench]
+            fn $name_for(b: &mut Bencher) {
+                b.iter(|| {
+                    let mut sum = 0;
+                    for n in IteratorTester::new($iter) {
+                        if n % 3 == 0 {
+                            let n2 = n / 3;
+                            if n2 % 3 == 0 {
+                                sum += n2;
+                            }
+                        }
+                    }
+                    sum
+                })
+            }
+            #[bench]
+            fn $name_fold(b: &mut Bencher) {
+                b.iter(|| {
+                    IteratorTester::new($iter).fold(0, |sum, n| {
+                        if n % 3 == 0 {
+                            let n2 = n / 3;
+                            if n2 % 3 == 0 {
+                                return sum + n2;
+                            }
+                        }
+                        sum
+                    })
+                })
+            }
+            #[bench]
+            fn $name_fold_mut(b: &mut Bencher) {
+                b.iter(|| IteratorTester::new($iter).fold_mut(0, |sum, n| mut_closure!(sum, n)))
+            }
+            #[bench]
+            fn $name_fold_mut_fold(b: &mut Bencher) {
+                b.iter(|| {
+                    IteratorTester::new($iter).fold_mut_fold(0, |sum, n| mut_closure!(sum, n))
+                })
+            }
+            #[bench]
+            fn $name_fold_mut_each(b: &mut Bencher) {
+                b.iter(|| {
+                    IteratorTester::new($iter).fold_mut_each(0, |sum, n| mut_closure!(sum, n))
+                })
+            }
+        };
+    }
+    test!(
+        bench_simple_for,
+        bench_simple_fold,
+        bench_simple_fold_mut,
+        bench_simple_fold_mut_fold,
+        bench_simple_fold_mut_each,
+        (0i64..100_000).map(black_box)
+    );
+    test!(
+        bench_chain_for,
+        bench_chain_fold,
+        bench_chain_fold_mut,
+        bench_chain_fold_mut_fold,
+        bench_chain_fold_mut_each,
+        (0i64..50_000).chain(0..50_000).map(black_box)
+    );
+    test!(
+        bench_flat_for,
+        bench_flat_fold,
+        bench_flat_fold_mut,
+        bench_flat_fold_mut_fold,
+        bench_flat_fold_mut_each,
+        (0i64..100_000).map(std::iter::once).flat_map(black_box)
+    );
+}
+
+#[cfg(test)]
+mod tuple_benches {
+    use super::*;
+    use test::{black_box, Bencher};
+
+    macro_rules! mut_closure {
+        ($nums:ident, $n:ident) => {
+            if $n % 3 == 0 {
+                let n2 = $n / 3;
+                if n2 % 3 == 0 {
+                    $nums[n2 as usize % $nums.len()] += n2;
+                }
+            }
+        };
+    }
+
+    macro_rules! test {
+        ($name_for:ident, $name_fold:ident, $name_fold_mut:ident, $name_fold_mut_fold:ident, $name_fold_mut_each:ident, $iter:expr) => {
+            #[bench]
+            fn $name_for(b: &mut Bencher) {
+                b.iter(|| {
+                    let mut nums = [0i64; 10];
+                    for n in IteratorTester::new($iter) {
+                        if n % 3 == 0 {
+                            let n2 = n / 3;
+                            if n2 % 3 == 0 {
+                                nums[n2 as usize % nums.len()] += n2;
+                            }
+                        }
+                    }
+                    nums
+                })
+            }
+            #[bench]
+            fn $name_fold(b: &mut Bencher) {
+                b.iter(|| {
+                    IteratorTester::new($iter).fold([0i64; 10], |mut nums, n| {
+                        if n % 3 == 0 {
+                            let n2 = n / 3;
+                            if n2 % 3 == 0 {
+                                nums[n2 as usize % nums.len()] += n2;
+                            }
+                        }
+                        nums
+                    })
+                })
+            }
+            #[bench]
+            fn $name_fold_mut(b: &mut Bencher) {
+                b.iter(|| {
+                    IteratorTester::new($iter).fold_mut([0i64; 10], |nums, n| mut_closure!(nums, n))
+                })
+            }
+            #[bench]
+            fn $name_fold_mut_fold(b: &mut Bencher) {
+                b.iter(|| {
+                    IteratorTester::new($iter)
+                        .fold_mut_fold([0i64; 10], |nums, n| mut_closure!(nums, n))
+                })
+            }
+            #[bench]
+            fn $name_fold_mut_each(b: &mut Bencher) {
+                b.iter(|| {
+                    IteratorTester::new($iter)
+                        .fold_mut_each([0i64; 10], |nums, n| mut_closure!(nums, n))
                 })
             }
         };


### PR DESCRIPTION
**This PR**
Tests the hypothesis that the performance of `fold` and `fold_mut_fold` vs `for`, `fold_mut`, and `fold_mut_each` is dependent on the size of the accumulator

**Why?**
I was wondering why the `Vec` tests were also so much slower for `fold`. I wondered if it was because the `Vec` is two `usize`s and a `Unique` while an `i64` is the size of one `usize` (on my machine).

**Results**

#### i64
```
test num_benches::bench_chain_fold             ... bench:     142,323 ns/iter (+/- 10,344)
test num_benches::bench_chain_fold_mut         ... bench:     251,547 ns/iter (+/- 14,298)
test num_benches::bench_chain_fold_mut_each    ... bench:     258,409 ns/iter (+/- 60,405)
test num_benches::bench_chain_fold_mut_fold    ... bench:     250,310 ns/iter (+/- 12,003)
test num_benches::bench_chain_for              ... bench:     156,844 ns/iter (+/- 15,476)

test num_benches::bench_flat_fold              ... bench:     145,278 ns/iter (+/- 11,958)
test num_benches::bench_flat_fold_mut          ... bench:     146,660 ns/iter (+/- 6,666)
test num_benches::bench_flat_fold_mut_each     ... bench:     142,380 ns/iter (+/- 8,004)
test num_benches::bench_flat_fold_mut_fold     ... bench:     147,105 ns/iter (+/- 5,219)
test num_benches::bench_flat_for               ... bench:     146,202 ns/iter (+/- 26,661)

test num_benches::bench_simple_fold            ... bench:     121,654 ns/iter (+/- 5,763)
test num_benches::bench_simple_fold_mut        ... bench:      92,458 ns/iter (+/- 7,835)
test num_benches::bench_simple_fold_mut_each   ... bench:      94,518 ns/iter (+/- 10,919)
test num_benches::bench_simple_fold_mut_fold   ... bench:      94,219 ns/iter (+/- 8,532)
test num_benches::bench_simple_for             ... bench:     134,160 ns/iter (+/- 3,410)
```

#### [i64; 10]
```
test tuple_benches::bench_chain_fold           ... bench:     412,976 ns/iter (+/- 7,208)
test tuple_benches::bench_chain_fold_mut       ... bench:     239,685 ns/iter (+/- 32,751)
test tuple_benches::bench_chain_fold_mut_each  ... bench:     237,561 ns/iter (+/- 7,886)
test tuple_benches::bench_chain_fold_mut_fold  ... bench:     414,235 ns/iter (+/- 20,479)
test tuple_benches::bench_chain_for            ... bench:     217,145 ns/iter (+/- 8,279)

test tuple_benches::bench_flat_fold            ... bench:     434,770 ns/iter (+/- 34,940)
test tuple_benches::bench_flat_fold_mut        ... bench:     236,290 ns/iter (+/- 12,824)
test tuple_benches::bench_flat_fold_mut_each   ... bench:     236,381 ns/iter (+/- 11,905)
test tuple_benches::bench_flat_fold_mut_fold   ... bench:     434,044 ns/iter (+/- 24,259)
test tuple_benches::bench_flat_for             ... bench:     242,236 ns/iter (+/- 25,758)

test tuple_benches::bench_simple_fold          ... bench:     413,871 ns/iter (+/- 15,624)
test tuple_benches::bench_simple_fold_mut      ... bench:     192,456 ns/iter (+/- 5,742)
test tuple_benches::bench_simple_fold_mut_each ... bench:     192,366 ns/iter (+/- 8,723)
test tuple_benches::bench_simple_fold_mut_fold ... bench:     410,464 ns/iter (+/- 16,882)
test tuple_benches::bench_simple_for           ... bench:     212,028 ns/iter (+/- 11,960)
```

#### `Vec<i64>`
```
test vec_benches::bench_chain_fold             ... bench:     374,994 ns/iter (+/- 16,868)
test vec_benches::bench_chain_fold_mut         ... bench:     291,529 ns/iter (+/- 9,157)
test vec_benches::bench_chain_fold_mut_each    ... bench:     283,967 ns/iter (+/- 12,812)
test vec_benches::bench_chain_fold_mut_fold    ... bench:     325,876 ns/iter (+/- 24,617)
test vec_benches::bench_chain_for              ... bench:     298,217 ns/iter (+/- 19,599)

test vec_benches::bench_flat_fold              ... bench:     346,642 ns/iter (+/- 26,683)
test vec_benches::bench_flat_fold_mut          ... bench:     293,599 ns/iter (+/- 21,014)
test vec_benches::bench_flat_fold_mut_each     ... bench:     270,286 ns/iter (+/- 15,026)
test vec_benches::bench_flat_fold_mut_fold     ... bench:     436,515 ns/iter (+/- 34,992)
test vec_benches::bench_flat_for               ... bench:     264,684 ns/iter (+/- 13,078)

test vec_benches::bench_simple_fold            ... bench:     298,264 ns/iter (+/- 6,612)
test vec_benches::bench_simple_fold_mut        ... bench:     211,203 ns/iter (+/- 6,637)
test vec_benches::bench_simple_fold_mut_each   ... bench:     208,434 ns/iter (+/- 5,946)
test vec_benches::bench_simple_fold_mut_fold   ... bench:     298,428 ns/iter (+/- 12,531)
test vec_benches::bench_simple_for             ... bench:     210,674 ns/iter (+/- 5,014)
```

## Todo
- [ ] Rename `tuple_benches` to `array_benches`
- [ ] Add `criterion` benchmarks for `num` and `array`